### PR TITLE
Add new design controls and extend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # ScopeCraft Telescope Designer
 
-This repository contains a simple browser-based telescope designer built with Maker.js and Tailwind CSS. Adjust mirror diameter, focal length, optical type, and mount style to see a live SVG preview. Use the **Export SVG** button to download your design.
+ScopeCraft is a lightweight browser application for quickly mocking up telescope designs. It uses [Maker.js](https://github.com/microsoft/maker.js/) to draw parts of the telescope and [Tailwind CSS](https://tailwindcss.com/) for styling.
 
-Open `index.html` in a web browser to try it out.
+## Features
+
+- Adjust mirror diameter and focal length using sliders.
+- Switch between refractor and Newtonian optical layouts.
+- Choose Dobsonian or Alt-Az mount styles.
+- Rotate the entire design to any angle.
+- Pick a custom color for the tube.
+- Optional finder scope that can be toggled on or off.
+- Live SVG preview that updates as you tweak settings.
+- Export the current design as an SVG file.
+
+## Getting Started
+
+No build step is required. Simply open `index.html` in any modern web browser. The controls on the left update the drawing on the right in real time.
+
+## Usage
+
+1. Move the **Mirror Diameter** and **Focal Length** sliders to size the telescope optics.
+2. Select the **Optical Type** and **Mount Style** from the dropdowns.
+3. Drag the **Orientation** slider to rotate the whole model.
+4. Use **Tube Color** to pick the stroke color for the SVG output.
+5. Toggle **Show Finder Scope** if you want a small finder on top of the tube.
+6. Click **Export SVG** to download the current design as an SVG file.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/app.js
+++ b/app.js
@@ -1,11 +1,14 @@
 class TelescopeDesigner {
   constructor() {
-    this.options = {
-      diameter: 200,
-      focalLength: 1000,
-      opticalType: 'refractor',
-      mount: 'dobsonian'
-    };
+      this.options = {
+        diameter: 200,
+        focalLength: 1000,
+        opticalType: 'refractor',
+        mount: 'dobsonian',
+        orientation: 0,
+        color: '#000000',
+        showFinder: true
+      };
     this.svgContainer = document.getElementById('svgContainer');
     this.downloadLink = document.getElementById('downloadLink');
     this.initControls();
@@ -17,12 +20,17 @@ class TelescopeDesigner {
     const focalInput = document.getElementById('focalLength');
     const opticalSelect = document.getElementById('opticalType');
     const mountSelect = document.getElementById('mount');
+    const orientationInput = document.getElementById('orientation');
+    const colorInput = document.getElementById('color');
+    const finderInput = document.getElementById('finder');
     const diameterValue = document.getElementById('diameterValue');
     const focalValue = document.getElementById('focalValue');
+    const orientationValue = document.getElementById('orientationValue');
 
     const syncValues = () => {
       diameterValue.textContent = this.options.diameter + ' mm';
       focalValue.textContent = this.options.focalLength + ' mm';
+      orientationValue.textContent = this.options.orientation + '°';
     };
 
     diameterInput.addEventListener('input', e => {
@@ -47,6 +55,22 @@ class TelescopeDesigner {
       this.updateModel();
     });
 
+    orientationInput.addEventListener('input', e => {
+      this.options.orientation = parseInt(e.target.value);
+      syncValues();
+      this.updateModel();
+    });
+
+    colorInput.addEventListener('input', e => {
+      this.options.color = e.target.value;
+      this.updateModel();
+    });
+
+    finderInput.addEventListener('change', e => {
+      this.options.showFinder = e.target.checked;
+      this.updateModel();
+    });
+
     syncValues();
   }
 
@@ -62,6 +86,11 @@ class TelescopeDesigner {
 
     model.models.tube = new m.Rectangle(length, diameter);
 
+    if (this.options.showFinder) {
+      const finder = new m.Rectangle(length * 0.2, diameter * 0.1);
+      model.models.finder = makerjs.model.move(finder, [length * 0.4, diameter]);
+    }
+
     if (this.options.opticalType === 'refractor') {
       model.paths.aperture = new p.Circle([length, diameter / 2], diameter / 2);
     } else {
@@ -75,12 +104,14 @@ class TelescopeDesigner {
       model.paths.mount = new p.Line([length / 2, -diameter / 2], [length / 2, -diameter]);
     }
 
+    makerjs.model.rotate(model, this.options.orientation, [0, 0]);
+
     return model;
   }
 
   updateModel() {
     const model = this.createModel();
-    const svg = makerjs.exporter.toSVG(model);
+    const svg = makerjs.exporter.toSVG(model, { stroke: this.options.color, fill: 'none' });
     this.svgContainer.innerHTML = svg;
     const blob = new Blob([svg], { type: 'image/svg+xml' });
     this.downloadLink.href = URL.createObjectURL(blob);

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body class="bg-gray-100 p-4">
   <h1 class="text-2xl font-bold mb-4">Telescope Designer</h1>
   <div class="flex flex-col md:flex-row gap-4">
-    <div class="basis-1/3 space-y-4">
+      <div class="basis-1/3 space-y-4">
       <div>
         <label class="block text-sm font-semibold" for="diameter">Mirror Diameter (mm)</label>
         <input type="range" id="diameter" min="50" max="500" value="200" class="w-full">
@@ -33,6 +33,21 @@
           <option value="dobsonian">Dobsonian</option>
           <option value="altaz">Alt-Az</option>
         </select>
+      </div>
+      <div>
+        <label class="block text-sm font-semibold" for="orientation">Orientation (deg)</label>
+        <input type="range" id="orientation" min="0" max="360" value="0" class="w-full">
+        <span id="orientationValue" class="text-sm"></span>
+      </div>
+      <div>
+        <label class="block text-sm font-semibold" for="color">Tube Color</label>
+        <input type="color" id="color" value="#000000" class="w-full h-10 p-0 border">
+      </div>
+      <div>
+        <label class="inline-flex items-center" for="finder">
+          <input type="checkbox" id="finder" class="mr-2" checked>
+          Show Finder Scope
+        </label>
       </div>
       <a id="downloadLink" href="#" download="telescope.svg" class="inline-block mt-2 bg-blue-500 text-white px-4 py-2 rounded">Export SVG</a>
     </div>


### PR DESCRIPTION
## Summary
- extend README with fuller instructions and usage information
- add orientation, color picker and finder scope options
- wire up new controls in JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68574a6787b48324a43f3e34e4f10b58