### PR TITLE
Fix Maker.js detection in TelescopeDesigner

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,13 @@ class TelescopeDesigner {
     this.svgContainer = document.getElementById('svgContainer');
     this.downloadLink = document.getElementById('downloadLink');
     this.makerjs = window.makerjs || window.MakerJs;
+    if (!this.makerjs && typeof window.require === 'function') {
+      try {
+        this.makerjs = window.require('makerjs');
+      } catch (e) {
+        /* ignore */
+      }
+    }
     if (!this.makerjs) {
       throw new Error('Maker.js library not found');
     }


### PR DESCRIPTION
## Summary
- detect Maker.js via Browserify's `require` function if the global variable isn't present

## Testing
- `npm view makerjs version`

------
https://chatgpt.com/codex/tasks/task_e_685c6a054e4c83248a59a289dc4df899