### PR TITLE
Add roadmap and implement optical metrics phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ ScopeCraft is a lightweight browser application for quickly mocking up telescope
 - Optional finder scope that can be toggled on or off.
 - Live SVG preview that updates as you tweak settings.
 - Export the current design as an SVG file.
+- Choose eyepiece presets and view live optical metrics (f/ratio, magnification, field of view, exit pupil, light gathering, resolution).
+- Inline tooltips explain how each control influences the design.
 
 ## Getting Started
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -72,9 +72,17 @@ describe('TelescopeDesigner', () => {
       <input id="orientation" type="range" value="0" />
       <span id="orientationValue"></span>
       <input id="color" type="color" value="#000000" />
+      <select id="eyepiece"></select>
       <input id="finder" type="checkbox" checked />
       <a id="downloadLink" href=""></a>
       <div id="svgContainer"></div>
+      <span id="metric-focalRatio"></span>
+      <span id="metric-magnification"></span>
+      <span id="metric-trueField"></span>
+      <span id="metric-exitPupil"></span>
+      <span id="metric-lightGathering"></span>
+      <span id="metric-resolution"></span>
+      <span id="metric-maxMagnification"></span>
     `;
 
     const downloadLink = document.getElementById('downloadLink');
@@ -173,5 +181,17 @@ describe('TelescopeDesigner', () => {
     expect(blobArg.parts).toEqual(['<svg></svg>']);
     expect(blobArg.type).toBe('image/svg+xml');
     expect(designer.downloadLink.href).toBe(createObjectURLMock.mock.results[0].value);
+  });
+
+  test('metrics panel displays derived values for default configuration', () => {
+    createDesigner();
+
+    expect(document.getElementById('metric-focalRatio').textContent).toBe('f/5.0');
+    expect(document.getElementById('metric-magnification').textContent).toBe('40×');
+    expect(document.getElementById('metric-trueField').textContent).toBe('1.25°');
+    expect(document.getElementById('metric-exitPupil').textContent).toBe('5.0 mm');
+    expect(document.getElementById('metric-lightGathering').textContent).toBe('816× human eye');
+    expect(document.getElementById('metric-resolution').textContent).toBe('0.58″');
+    expect(document.getElementById('metric-maxMagnification').textContent).toBe('400×');
   });
 });

--- a/__tests__/calculations.test.js
+++ b/__tests__/calculations.test.js
@@ -1,0 +1,23 @@
+const calculations = require('../calculations');
+
+describe('calculations', () => {
+  test('computes fundamental telescope metrics', () => {
+    expect(calculations.calculateFocalRatio(200, 1000)).toBeCloseTo(5);
+    expect(calculations.calculateMagnification(1000, 25)).toBeCloseTo(40);
+    expect(calculations.calculateTrueFieldOfView(1000, 25, 50)).toBeCloseTo(1.25);
+    expect(calculations.calculateExitPupil(200, 40)).toBeCloseTo(5);
+    expect(calculations.calculateLightGatheringPower(200)).toBeCloseTo(816.3265, 4);
+    expect(calculations.calculateResolutionLimit(200)).toBeCloseTo(0.58);
+    expect(calculations.calculateMaxUsefulMagnification(200)).toBe(400);
+  });
+
+  test('returns null for invalid inputs', () => {
+    expect(calculations.calculateFocalRatio(0, 1000)).toBeNull();
+    expect(calculations.calculateMagnification(1000, 0)).toBeNull();
+    expect(calculations.calculateTrueFieldOfView(1000, 0, 50)).toBeNull();
+    expect(calculations.calculateExitPupil(200, 0)).toBeNull();
+    expect(calculations.calculateLightGatheringPower(200, 0)).toBeNull();
+    expect(calculations.calculateResolutionLimit(0)).toBeNull();
+    expect(calculations.calculateMaxUsefulMagnification('not a number')).toBeNull();
+  });
+});

--- a/calculations.js
+++ b/calculations.js
@@ -1,0 +1,73 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ScopeCraftCalculations = factory();
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function isFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  function safeDivide(numerator, denominator) {
+    if (!isFiniteNumber(numerator) || !isFiniteNumber(denominator) || denominator === 0) {
+      return null;
+    }
+    return numerator / denominator;
+  }
+
+  function calculateFocalRatio(apertureMm, focalLengthMm) {
+    return safeDivide(focalLengthMm, apertureMm);
+  }
+
+  function calculateMagnification(focalLengthMm, eyepieceFocalLengthMm) {
+    return safeDivide(focalLengthMm, eyepieceFocalLengthMm);
+  }
+
+  function calculateTrueFieldOfView(focalLengthMm, eyepieceFocalLengthMm, eyepieceApparentFoVDeg) {
+    if (!isFiniteNumber(eyepieceApparentFoVDeg)) {
+      return null;
+    }
+    const magnification = calculateMagnification(focalLengthMm, eyepieceFocalLengthMm);
+    if (!isFiniteNumber(magnification) || magnification === 0) {
+      return null;
+    }
+    return eyepieceApparentFoVDeg / magnification;
+  }
+
+  function calculateExitPupil(apertureMm, magnification) {
+    return safeDivide(apertureMm, magnification);
+  }
+
+  function calculateLightGatheringPower(apertureMm, referenceMm = 7) {
+    if (!isFiniteNumber(apertureMm) || !isFiniteNumber(referenceMm) || referenceMm === 0) {
+      return null;
+    }
+    const ratio = apertureMm / referenceMm;
+    return ratio * ratio;
+  }
+
+  function calculateResolutionLimit(apertureMm) {
+    if (!isFiniteNumber(apertureMm) || apertureMm === 0) {
+      return null;
+    }
+    return 116 / apertureMm;
+  }
+
+  function calculateMaxUsefulMagnification(apertureMm) {
+    if (!isFiniteNumber(apertureMm)) {
+      return null;
+    }
+    return apertureMm * 2;
+  }
+
+  return {
+    calculateExitPupil,
+    calculateFocalRatio,
+    calculateLightGatheringPower,
+    calculateMagnification,
+    calculateMaxUsefulMagnification,
+    calculateResolutionLimit,
+    calculateTrueFieldOfView
+  };
+});

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,78 @@
+# ScopeCraft Roadmap
+
+This plan translates the AGENT goals into a sequenced roadmap. Each phase is scoped so that we can iterate while continuously shipping improvements.
+
+## Phase 1 – Observation Insights & Control Enhancements
+**Objectives**
+- Add contextual help so newcomers understand each optical parameter.
+- Surface key optical metrics (focal ratio, field of view estimates, magnification, resolution, light gathering) that update live.
+- Introduce eyepiece presets so users can explore magnifications quickly.
+- Establish a calculation module with unit-tested formulas to support later features.
+
+**Key Deliverables**
+- Tooltip system tied to existing controls and new metrics panel.
+- Reusable utilities for telescope/eyepiece calculations with Jest coverage.
+- Extended UI controls (eyepiece selector) with clean state updates.
+
+**Dependencies**
+- None. This phase lays the computational groundwork that later phases reuse.
+
+## Phase 2 – Visualization & Interaction Upgrades
+**Objectives**
+- Improve preview ergonomics with zoom/pan and measurement overlays.
+- Offer side-by-side comparisons of multiple configurations.
+- Integrate optional 3D preview (Three.js) scaffold that mirrors 2D design state.
+
+**Key Deliverables**
+- Refactored rendering pipeline to support layered annotations.
+- Comparison view state handling and UI layout.
+- Lazy-loaded Three.js module with a minimal 3D representation.
+
+**Dependencies**
+- Relies on the calculation utilities and structured state from Phase 1.
+
+## Phase 3 – Export, Reporting & Sharing
+**Objectives**
+- Expand export options (PNG, PDF, DXF) and include a rich specification report.
+- Generate BOM/parts list derived from design parameters.
+- Enable sharing via serialized URLs or saved design blobs.
+
+**Key Deliverables**
+- Export service abstraction with multiple format adapters.
+- Parts list generator reusing calculation utilities.
+- Shareable design encoder/decoder with validation.
+
+**Dependencies**
+- Calculation utilities (Phase 1) and visual refactors (Phase 2) for accurate exports.
+
+## Phase 4 – Educational & Guided Experiences
+**Objectives**
+- Add Explain mode with inline copy describing the impact of changes.
+- Provide ray diagram overlays and interactive tutorials/guided flows.
+- Link to curated learning resources contextual to the user’s current design.
+
+**Key Deliverables**
+- Explain mode toggle integrated with tooltips/metrics.
+- Ray tracing visualization leveraging Maker.js geometries.
+- Tutorial state machine with progressive disclosure content.
+
+**Dependencies**
+- Builds on visualization upgrades (Phase 2) and calculation accuracy (Phase 1).
+
+## Phase 5 – Architecture, Performance & Extensibility
+**Objectives**
+- Transition to modular architecture with dedicated state management (e.g., Zustand).
+- Add TypeScript for type safety and improved maintainability.
+- Optimize rendering for complex designs and cache heavy computations.
+- Expand telescope types, mounts, and accessories with cost estimation.
+- Set up user accounts, design saving, and collaboration primitives.
+
+**Key Deliverables**
+- Bundler/tooling configuration supporting TS and modular code.
+- State management layer with persistence capabilities.
+- Performance profiling tools and caching mechanisms.
+- Extensible schema for telescope/mount/accessory catalogs.
+- Backend/API interface stubs for auth and shared designs.
+
+**Dependencies**
+- Earlier phases ensure the UX foundation is strong before tackling structural overhauls.

--- a/index.html
+++ b/index.html
@@ -5,43 +5,128 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Telescope Designer</title>
   <link rel="stylesheet" href="tailwind.css">
+  <style>
+    .tooltip {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.25rem;
+      height: 1.25rem;
+      margin-left: 0.25rem;
+      border-radius: 9999px;
+      background-color: rgba(59, 130, 246, 0.15);
+      color: #1d4ed8;
+      font-size: 0.75rem;
+      font-weight: 600;
+      cursor: default;
+    }
+
+    .tooltip::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      bottom: calc(100% + 0.5rem);
+      min-width: 12rem;
+      max-width: 16rem;
+      padding: 0.5rem;
+      border-radius: 0.375rem;
+      background: rgba(17, 24, 39, 0.9);
+      color: #f9fafb;
+      font-size: 0.75rem;
+      line-height: 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease;
+      z-index: 10;
+      text-align: left;
+    }
+
+    .tooltip::before {
+      content: '';
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      bottom: calc(100% + 0.25rem);
+      border-width: 0.375rem 0.375rem 0;
+      border-style: solid;
+      border-color: rgba(17, 24, 39, 0.9) transparent transparent;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      pointer-events: none;
+      z-index: 11;
+    }
+
+    .tooltip:focus::after,
+    .tooltip:focus::before,
+    .tooltip:hover::after,
+    .tooltip:hover::before {
+      opacity: 1;
+    }
+  </style>
 </head>
 <body class="bg-gray-100 p-4">
   <h1 class="text-2xl font-bold mb-4">Telescope Designer</h1>
   <div class="flex flex-col md:flex-row gap-4">
-      <div class="basis-1/3 space-y-4">
+    <div class="basis-1/3 space-y-4">
       <div>
-        <label class="block text-sm font-semibold" for="diameter">Mirror Diameter (mm)</label>
+        <label class="block text-sm font-semibold" for="diameter">
+          Mirror Diameter (mm)
+          <span class="tooltip" tabindex="0" data-tooltip="Sets the aperture of the telescope. Larger apertures collect more light and improve resolution.">?</span>
+        </label>
         <input type="range" id="diameter" min="50" max="500" value="200" class="w-full">
         <span id="diameterValue" class="text-sm"></span>
       </div>
       <div>
-        <label class="block text-sm font-semibold" for="focalLength">Focal Length (mm)</label>
+        <label class="block text-sm font-semibold" for="focalLength">
+          Focal Length (mm)
+          <span class="tooltip" tabindex="0" data-tooltip="Controls the distance light travels to focus. Longer focal lengths yield higher magnification with the same eyepiece.">?</span>
+        </label>
         <input type="range" id="focalLength" min="100" max="2000" value="1000" class="w-full">
         <span id="focalValue" class="text-sm"></span>
       </div>
       <div>
-        <label class="block text-sm font-semibold" for="opticalType">Optical Type</label>
+        <label class="block text-sm font-semibold" for="opticalType">
+          Optical Type
+          <span class="tooltip" tabindex="0" data-tooltip="Switch between refractor and Newtonian layouts. Newtonians use a secondary mirror to direct light to the side.">?</span>
+        </label>
         <select id="opticalType" class="w-full border p-1">
           <option value="refractor">Refractor</option>
           <option value="newtonian">Newtonian</option>
         </select>
       </div>
       <div>
-        <label class="block text-sm font-semibold" for="mount">Mount Style</label>
+        <label class="block text-sm font-semibold" for="mount">
+          Mount Style
+          <span class="tooltip" tabindex="0" data-tooltip="Dobsonian mounts are simple alt-az designs. Alt-az mounts offer manual altitude and azimuth adjustment.">?</span>
+        </label>
         <select id="mount" class="w-full border p-1">
           <option value="dobsonian">Dobsonian</option>
           <option value="altaz">Alt-Az</option>
         </select>
       </div>
       <div>
-        <label class="block text-sm font-semibold" for="orientation">Orientation (deg)</label>
+        <label class="block text-sm font-semibold" for="orientation">
+          Orientation (deg)
+          <span class="tooltip" tabindex="0" data-tooltip="Rotate the entire telescope drawing to view it from any angle.">?</span>
+        </label>
         <input type="range" id="orientation" min="0" max="360" value="0" class="w-full">
         <span id="orientationValue" class="text-sm"></span>
       </div>
       <div>
-        <label class="block text-sm font-semibold" for="color">Tube Color</label>
+        <label class="block text-sm font-semibold" for="color">
+          Tube Color
+          <span class="tooltip" tabindex="0" data-tooltip="Choose the accent color used for the telescope drawing and exports.">?</span>
+        </label>
         <input type="color" id="color" value="#000000" class="w-full h-10 p-0 border">
+      </div>
+      <div>
+        <label class="block text-sm font-semibold" for="eyepiece">
+          Eyepiece Preset
+          <span class="tooltip" tabindex="0" data-tooltip="Select an eyepiece to see the resulting magnification, field of view, and exit pupil.">?</span>
+        </label>
+        <select id="eyepiece" class="w-full border p-1"></select>
       </div>
       <div>
         <label class="inline-flex items-center" for="finder">
@@ -51,10 +136,49 @@
       </div>
       <a id="downloadLink" href="#" download="telescope.svg" class="inline-block mt-2 bg-blue-500 text-white px-4 py-2 rounded">Export SVG</a>
     </div>
-    <div id="svgContainer" class="basis-2/3 bg-white p-2 border"></div>
+    <div class="basis-2/3 space-y-4">
+      <div id="svgContainer" class="bg-white p-2 border min-h-[320px]"></div>
+      <section class="bg-white p-4 border rounded space-y-2" aria-labelledby="metricsHeading">
+        <div class="flex items-center justify-between">
+          <h2 id="metricsHeading" class="text-lg font-semibold">Optical Metrics</h2>
+          <span class="tooltip" tabindex="0" data-tooltip="Live calculations update as you tweak the telescope. Values are estimates meant for quick comparisons.">i</span>
+        </div>
+        <dl class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+          <div class="flex justify-between">
+            <dt class="font-medium">Focal Ratio</dt>
+            <dd id="metric-focalRatio">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">Magnification</dt>
+            <dd id="metric-magnification">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">True Field of View</dt>
+            <dd id="metric-trueField">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">Exit Pupil</dt>
+            <dd id="metric-exitPupil">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">Light Gathering</dt>
+            <dd id="metric-lightGathering">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">Resolution Limit</dt>
+            <dd id="metric-resolution">—</dd>
+          </div>
+          <div class="flex justify-between">
+            <dt class="font-medium">Max Useful Magnification</dt>
+            <dd id="metric-maxMagnification">—</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
   </div>
 
   <script src="maker.js"></script>
-  <script type="module" src="app.js"></script>
+  <script src="calculations.js" defer></script>
+  <script src="app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a five-phase roadmap that maps AGENT goals into actionable milestones
- create shared calculation utilities with coverage and wire them into the designer UI
- extend the interface with tooltips, eyepiece presets, and a live metrics panel

## Testing
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cb1b97f18c83249e08b9011ead5c4e